### PR TITLE
Removing not used parameter from constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/*
 .settings/*
 MDI_javalib/target/*
 VRDR_javalib/target/*
+.DS_Store

--- a/MDI_javalib/pom.xml
+++ b/MDI_javalib/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.gatech.chai</groupId>
   <artifactId>MDI</artifactId>
-  <version>1.2.13-STU-2.0.0-US</version>
+  <version>1.2.14-STU-2.0.0-US</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>edu.gatech.chai</groupId>
       <artifactId>vrdr</artifactId>
-      <version>5.2.2</version>
+      <version>5.2.3</version>
   </dependency>
   </dependencies>
 

--- a/MDI_javalib/src/main/java/edu/gatech/chai/MDI/model/resource/BundleMessageDeathCertificateReview.java
+++ b/MDI_javalib/src/main/java/edu/gatech/chai/MDI/model/resource/BundleMessageDeathCertificateReview.java
@@ -19,23 +19,14 @@ public class BundleMessageDeathCertificateReview extends Bundle{
 		super();
 	}
 
-	public BundleMessageDeathCertificateReview(BundleType bundleType, MessageHeaderDCR messageHeaderEntry, BundleDocumentMDIDCR bundleDocumentEntry) {
+	public BundleMessageDeathCertificateReview(BundleType bundleType, MessageHeaderDCR messageHeaderEntry) {
 		super();
+
 		this.setType(bundleType);
 		this.setIdentifier(identifier);
-		BundleEntryComponent mhEntry = new BundleEntryComponent();
-		String mhRefUrl = "urn:uuid:" + UUID.randomUUID().toString();
-		mhEntry.setFullUrl(mhRefUrl);
-		mhEntry.setResource(messageHeaderEntry);
-		this.addEntry(mhEntry);
-
-		BundleEntryComponent bDcrEntry = new BundleEntryComponent();
-		String bDcrRefUrl = "urn:uuid:" + UUID.randomUUID().toString();
-		bDcrEntry.setFullUrl(bDcrRefUrl);
-		bDcrEntry.setResource(bundleDocumentEntry);
-		this.addEntry(bDcrEntry);
-
-		messageHeaderEntry.addFocus(new Reference(bDcrRefUrl));
+		BundleEntryComponent bec = new BundleEntryComponent();
+		bec.setResource(messageHeaderEntry);
+		this.addEntry(bec);
 	}
 	
 	//This MessageHeader must always be the correct case here.

--- a/MDI_javalib/src/main/java/edu/gatech/chai/MDI/model/resource/BundleMessageDeathCertificateReview.java
+++ b/MDI_javalib/src/main/java/edu/gatech/chai/MDI/model/resource/BundleMessageDeathCertificateReview.java
@@ -1,10 +1,6 @@
 package edu.gatech.chai.MDI.model.resource;
 
-import java.util.UUID;
-
 import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.Identifier;
-import org.hl7.fhir.r4.model.Reference;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
 
@@ -21,7 +17,6 @@ public class BundleMessageDeathCertificateReview extends Bundle{
 
 	public BundleMessageDeathCertificateReview(BundleType bundleType, MessageHeaderDCR messageHeaderEntry) {
 		super();
-
 		this.setType(bundleType);
 		this.setIdentifier(identifier);
 		BundleEntryComponent bec = new BundleEntryComponent();

--- a/MDI_javalib/src/main/java/edu/gatech/chai/MDI/model/resource/BundleMessageDeathCertificateReview.java
+++ b/MDI_javalib/src/main/java/edu/gatech/chai/MDI/model/resource/BundleMessageDeathCertificateReview.java
@@ -1,7 +1,10 @@
 package edu.gatech.chai.MDI.model.resource;
 
+import java.util.UUID;
+
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Reference;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
 
@@ -20,9 +23,19 @@ public class BundleMessageDeathCertificateReview extends Bundle{
 		super();
 		this.setType(bundleType);
 		this.setIdentifier(identifier);
-		BundleEntryComponent bec = new BundleEntryComponent();
-		bec.setResource(messageHeaderEntry);
-		this.addEntry(bec);
+		BundleEntryComponent mhEntry = new BundleEntryComponent();
+		String mhRefUrl = "urn:uuid:" + UUID.randomUUID().toString();
+		mhEntry.setFullUrl(mhRefUrl);
+		mhEntry.setResource(messageHeaderEntry);
+		this.addEntry(mhEntry);
+
+		BundleEntryComponent bDcrEntry = new BundleEntryComponent();
+		String bDcrRefUrl = "urn:uuid:" + UUID.randomUUID().toString();
+		bDcrEntry.setFullUrl(bDcrRefUrl);
+		bDcrEntry.setResource(bundleDocumentEntry);
+		this.addEntry(bDcrEntry);
+
+		messageHeaderEntry.addFocus(new Reference(bDcrRefUrl));
 	}
 	
 	//This MessageHeader must always be the correct case here.


### PR DESCRIPTION
It makes sense that urls and ids are not set by the library if users have issues with that. 

That constructor has a parameter that is not used in the constructor. This will make incomplete bundle message in the user code because passing the bundleDocumentEntry in constructor means it will be added in the entry and focus is added. If this action will not be done by constructor, then this constructor should not take the bundleDocumentEntry resource as a parameter.

Suggesting to remove the parameter from the constructor. 